### PR TITLE
Disables SACK.

### DIFF
--- a/etc/sysctl.d/tcp_sack.conf
+++ b/etc/sysctl.d/tcp_sack.conf
@@ -1,0 +1,2 @@
+# Disables SACK as it is commonly exploited and likely not needed.
+net.ipv4.tcp_sack=0


### PR DESCRIPTION
SACK is commonly exploited and likely not needed. It may be best to disable it.