### PR TITLE
Add some hardening for other distributions

### DIFF
--- a/etc/sysctl.d/dmesg_restrict.conf
+++ b/etc/sysctl.d/dmesg_restrict.conf
@@ -1,0 +1,2 @@
+# Restricts the kernel log to root only.
+kernel.dmesg_restrict=1

--- a/etc/sysctl.d/tcp_hardening.conf
+++ b/etc/sysctl.d/tcp_hardening.conf
@@ -15,5 +15,12 @@ net.ipv6.conf.default.accept_redirects=0
 net.ipv4.conf.all.send_redirects=0
 net.ipv4.conf.default.send_redirects=0
 
-# Ignores ICMP requests
+# Ignores ICMP requests.
 net.ipv4.icmp_echo_ignore_all=1
+
+# Enables TCP syncookies.
+net.ipv4.tcp_syncookies=1
+
+# Disable source routing.
+net.ipv4.conf.all.accept_source_route=0
+net.ipv4.conf.default.accept_source_route=0


### PR DESCRIPTION
Debian (and by extension, Whonix) enables these settings by default but other distros (that are using security-misc) may not. This also makes sure that some default settings don't get changed after an update.

It sets `kernel.dmesg_restrict=1` with sysctl to restrict the kernel log to the root user, enables TCP syncookies to prevent SYN flood attacks and disables [source routing](https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/6/html/security_guide/sect-security_guide-server_security-disable-source-routing).