### PR TITLE
Blacklist more uncommon network protocols

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -97,7 +97,7 @@ Description: enhances misc security settings
  .
  All mitigations for the MDS vulnerability are enabled.
  .
- DCCP, SCTP, TIPC, RDS and HDLC are blacklisted as they are rarely used and
+ DCCP, SCTP, TIPC, RDS, HDLC, ax25, netrom, x25, rose, decnet, econet and af_80215 are blacklisted as they are rarely used and
  may have unknown vulnerabilities.
  .
  The kernel logs are restricted to root only.

--- a/debian/control
+++ b/debian/control
@@ -97,7 +97,7 @@ Description: enhances misc security settings
  .
  All mitigations for the MDS vulnerability are enabled.
  .
- DCCP, SCTP, TIPC, RDS, HDLC, ax25, netrom, x25, rose, decnet, econet and af_80215 are blacklisted as they are rarely used and
+ Uncommon network protocols are blacklisted as they are rarely used and
  may have unknown vulnerabilities.
  .
  The kernel logs are restricted to root only.

--- a/etc/modprobe.d/uncommon-network-protocols.conf
+++ b/etc/modprobe.d/uncommon-network-protocols.conf
@@ -10,5 +10,4 @@ install x25 /bin/true
 install rose /bin/true
 install decnet /bin/true
 install econet /bin/true
-install rds /bin/true
 install af_802154 /bin/true

--- a/etc/modprobe.d/uncommon-network-protocols.conf
+++ b/etc/modprobe.d/uncommon-network-protocols.conf
@@ -4,3 +4,11 @@ install sctp /bin/true
 install rds /bin/true
 install tipc /bin/true
 install n-hdlc /bin/true
+install ax25 /bin/true
+install netrom /bin/true
+install x25 /bin/true
+install rose /bin/true
+install decnet /bin/true
+install econet /bin/true
+install rds /bin/true
+install af_802154 /bin/true

--- a/etc/modprobe.d/uncommon-network-protocols.conf
+++ b/etc/modprobe.d/uncommon-network-protocols.conf
@@ -11,3 +11,9 @@ install rose /bin/true
 install decnet /bin/true
 install econet /bin/true
 install af_802154 /bin/true
+install ipx /bin/true
+install appletalk /bin/true
+install psnap /bin/true
+install p8023 /bin/true
+install llc /bin/true
+install p8022 /bin/true


### PR DESCRIPTION
Fedora and Ubuntu also blacklist these.