### PR TITLE
Require all loaded kernel modules to be signed with a valid key.

### DIFF
--- a/etc/default/grub.d/40_only_allow_signed_modules.cfg
+++ b/etc/default/grub.d/40_only_allow_signed_modules.cfg
@@ -1,0 +1,3 @@
+# Requires every module to be signed before being loaded. Any module that is unsigned or signed with an invalid key cannot be loaded.
+# This makes it harder to load a malicious module.
+GRUB_CMDLINE_LINUX="$GRUB_CMDLINE_LINUX module.sig_enforce=1"


### PR DESCRIPTION
See https://forums.whonix.org/t/allow-loading-signed-kernel-modules-by-default-disallow-kernel-module-loading-by-default/7880