### PR TITLE
fix typo

### DIFF
--- a/etc/default/grub.d/40_kernel_hardening.cfg
+++ b/etc/default/grub.d/40_kernel_hardening.cfg
@@ -2,7 +2,7 @@
 GRUB_CMDLINE_LINUX="$GRUB_CMDLINE_LINUX slab_nomerge"
 
 # Enables sanity checks (F), redzoning (Z) and poisoning (P).
-GRUB_CMDLINE_LINUX="$GRUB_CMDLINE_LINUX slab_debug=FZP"
+GRUB_CMDLINE_LINUX="$GRUB_CMDLINE_LINUX slub_debug=FZP"
 
 # Wipes free memory so it can't leak in various ways and prevents some use-after-free vulnerabilites.
 GRUB_CMDLINE_LINUX="$GRUB_CMDLINE_LINUX page_poison=1"


### PR DESCRIPTION
It should be `slub_debug` instead of `slab_debug`.

Pointed out here https://forums.whonix.org/t/kernel-hardening/7296/184