### PR TITLE
Restrict /proc/cpuinfo, /proc/bus, /proc/scsi and /sys to root

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -85,6 +85,13 @@ Description: enhances misc security settings
  a history of security concerns.
  https://en.wikipedia.org/wiki/Bluetooth#History_of_security_concerns
  .
+  * A systemd service restricts /proc/cpuinfo, /proc/bus, /proc/scsi and
+ /sys to the root user only. This hides a lot of hardware identifiers from
+ unprivileged users and increases security as /sys exposes a lot of information
+ that shouldn't be accessible to unprivileged users. As this will break many
+ things, it is disabled by default and can optionally be enabled by running
+ `systemctl enable hide-hardware-info.service` as root.
+ .
  Uncommon network protocols are blacklisted:
  These are rarely used and may have unknown vulnerabilities.
  /etc/modprobe.d/uncommon-network-protocols.conf

--- a/lib/systemd/system-preset/50-security-misc.preset
+++ b/lib/systemd/system-preset/50-security-misc.preset
@@ -1,0 +1,4 @@
+## Copyright (C) 2012 - 2018 ENCRYPTED SUPPORT LP <adrelanos@riseup.net>
+## See the file COPYING for copying conditions.
+
+disable hide-hardware-info.service

--- a/lib/systemd/system/hide-hardware-info.service
+++ b/lib/systemd/system/hide-hardware-info.service
@@ -1,3 +1,6 @@
+## Copyright (C) 2012 - 2018 ENCRYPTED SUPPORT LP <adrelanos@riseup.net>
+## See the file COPYING for copying conditions.
+
 [Unit]
 Description=Hide hardware information to unprivileged users
 Documentation=https://github.com/Whonix/security-misc

--- a/lib/systemd/system/hide-hardware-info.service
+++ b/lib/systemd/system/hide-hardware-info.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=Hide hardware information to unprivileged users
+Documentation=https://github.com/Whonix/security-misc
+DefaultDependencies=no
+Before=sysinit.target
+Requires=local-fs.target
+After=local-fs.target
+
+[Service]
+Type=oneshot
+ExecStart=/usr/lib/security-misc/hide-hardware-info
+
+[Install]
+WantedBy=multi-user.target

--- a/lib/systemd/system/hide-hardware-info.service
+++ b/lib/systemd/system/hide-hardware-info.service
@@ -14,4 +14,4 @@ Type=oneshot
 ExecStart=/usr/lib/security-misc/hide-hardware-info
 
 [Install]
-WantedBy=multi-user.target
+WantedBy=sysinit.target

--- a/usr/lib/security-misc/hide-hardware-info
+++ b/usr/lib/security-misc/hide-hardware-info
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+## Copyright (C) 2012 - 2018 ENCRYPTED SUPPORT LP <adrelanos@riseup.net>
+## See the file COPYING for copying conditions.
+
 ## sysfs and debugfs expose a lot of information
 ## that should not be accessible by an unprivileged
 ## user which includes hardware info, debug info and

--- a/usr/lib/security-misc/hide-hardware-info
+++ b/usr/lib/security-misc/hide-hardware-info
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+## sysfs and debugfs expose a lot of information
+## that should not be accessible by an unprivileged
+## user which includes hardware info, debug info and
+## more. This restricts /sys, /proc/cpuinfo, /proc/bus
+## and /proc/scsi to the root user only. This hides
+## many hardware identifiers from ordinary users
+## and increases security.
+for i in /proc/cpuinfo /proc/bus /proc/scsi /sys
+do
+  if [ -e "${i}" ]; then
+    chmod og-rwx "${i}"
+  else
+    ## /proc/scsi doesn't exist on Debian so errors
+    ## are expected here.
+    if ! [ "${i}" = "/proc/scsi" ]; then
+      echo "ERROR: ${i} could not be found."
+    fi
+  fi
+done


### PR DESCRIPTION
This hides hardware information to unprivileged users and increases security. See https://forums.whonix.org/t/anonymize-etc-machine-id/7721/21 and https://forums.whonix.org/t/restrict-hardware-information-to-root/7329/