### PR TITLE
Remove proc-hidepid systemd sandboxing

### DIFF
--- a/lib/systemd/system/proc-hidepid.service
+++ b/lib/systemd/system/proc-hidepid.service
@@ -13,23 +13,5 @@ After=local-fs.target
 Type=oneshot
 ExecStart=/bin/mount -o remount,nosuid,nodev,noexec,hidepid=2 /proc
 
-## Disabled since not working in Qubes.
-#ProtectSystem=strict
-#ProtectHome=true
-#ProtectKernelTunables=true
-#ProtectKernelModules=true
-#ProtectControlGroups=true
-#PrivateTmp=true
-#PrivateMounts=true
-#PrivateDevices=true
-#MemoryDenyWriteExecute=true
-#NoNewPrivileges=true
-#RestrictRealtime=true
-#SystemCallArchitectures=native
-#RestrictNamespaces=true
-#SystemCallFilter=mount munmap access read open close stat fstat lstat mmap mprotect brk rt_sigaction rt_sigprocmask execve readlink getrlimit getuid getgid geteuid getegid statfs prctl arch_prctl set_tid_address newfstatat set_robust_list openat mkdir
-
-PrivateNetwork=true
-
 [Install]
 WantedBy=sysinit.target


### PR DESCRIPTION
There is barely any security gain and `PrivateNetwork=true` breaks when using apparmor-profile-everything