### PR TITLE
Prevent symlink/hardlink TOCTOU races

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -48,7 +48,9 @@ Description: enhances misc security settings
  attacks and enabling reverse path filtering to prevent IP spoofing and
  mitigate vulnerabilities such as CVE-2019-14899.
  .
-  * Some data spoofing attacks are made harder.
+  * Avoids unintentional writes to attacker-controlled files.
+ .
+  * Prevents symlink/hardlink TOCTOU races.
  .
   * SACK can be disabled as it is commonly exploited and is rarely used by
  uncommenting settings in file /etc/sysctl.d/30_security-misc.conf.

--- a/etc/sysctl.d/30_security-misc.conf
+++ b/etc/sysctl.d/30_security-misc.conf
@@ -5,20 +5,30 @@
 ## security-misc also disables coredumps in other ways.
 kernel.core_pattern=|/bin/false
 
-
 ## Restricts the kernel log to root only.
 kernel.dmesg_restrict=1
 
-
-## Makes some data spoofing attacks harder.
+## Don't allow writes to files that we don't own
+## in world writable sticky directories, unless
+## they are owned by the owner of the directory.
 fs.protected_fifos=2
 fs.protected_regular=2
 
+## Only allow symlinks to be followed when outside of
+## a world-writable sticky directory, or when the owner
+## of the symlink and follower match, or when the directory
+## owner matches the symlink's owner.
+##
+## Prevent hardlinks from being created by users that do not
+## have read/write access to the source file.
+##
+## These prevent many TOCTOU races.
+fs.protected_symlinks=1
+fs.protected_hardlinks=1
 
 ## Hardens the BPF JIT compiler and restricts it to root.
 kernel.unprivileged_bpf_disabled=1
 net.core.bpf_jit_harden=2
-
 
 ## Quote https://www.kernel.org/doc/html/latest/admin-guide/sysctl/kernel.html
 ##
@@ -29,18 +39,15 @@ net.core.bpf_jit_harden=2
 ## Disables kexec which can be used to replace the running kernel.
 kernel.kexec_load_disabled=1
 
-
 ## Hides kernel addresses in various files in /proc.
 ## Kernel addresses can be very useful in certain exploits.
 ##
 ## https://kernsec.org/wiki/index.php/Bug_Classes/Kernel_pointer_leak
 kernel.kptr_restrict=2
 
-
 ## Improves ASLR effectiveness for mmap.
 vm.mmap_rnd_bits=32
 vm.mmap_rnd_compat_bits=16
-
 
 ## Restricts the use of ptrace to root. This might break some programs running under WINE.
 ## A workaround for WINE would be to give the wineserver and wine-preloader ptrace capabilities. This can be done by running:
@@ -49,7 +56,6 @@ vm.mmap_rnd_compat_bits=16
 ## sudo setcap cap_sys_ptrace=eip /usr/bin/wineserver
 ## sudo setcap cap_sys_ptrace=eip /usr/bin/wine-preloader
 kernel.yama.ptrace_scope=2
-
 
 ## Prevent setuid processes from creating coredumps.
 fs.suid_dumpable=0


### PR DESCRIPTION
These sysctls are enabled by default on Debian but this can help other distros.

Also improves the description of `fs.protected_{fifos,regular}` and removes unneeded whitespace.