### PR TITLE
Improve CPU mitigations documentation

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -66,12 +66,7 @@ Description: enhances misc security settings
   * Kernel Page Table Isolation is enabled to mitigate Meltdown and increase
  KASLR effectiveness.
  .
-  * SMT is disabled as it can be used to exploit the MDS and other
- vulnerabilities.
- .
-  * All mitigations for the MDS vulnerability are enabled.
- .
-  * Enables mitigations for the L1TF (L1 Terminal Fault) vulnerability.
+  * Enables all mitigations for CPU vulnerabilities and disables SMT.
  .
   * A systemd service clears System.map on boot as these contain kernel symbols
  that could be useful to an attacker.

--- a/etc/default/grub.d/40_cpu_mitigations.cfg
+++ b/etc/default/grub.d/40_cpu_mitigations.cfg
@@ -1,0 +1,42 @@
+## Copyright (C) 2019 - 2019 ENCRYPTED SUPPORT LP <adrelanos@riseup.net>
+## See the file COPYING for copying conditions.
+
+## Enables all mitigations for CPU vulnerabilities.
+##
+## https://forums.whonix.org/t/should-all-kernel-patches-for-cpu-bugs-be-unconditionally-enabled-vs-performance-vs-applicability/7647
+
+## Enable all mitigations for Spectre Variant 2.
+##
+## https://www.kernel.org/doc/html/latest/admin-guide/hw-vuln/spectre.html
+GRUB_CMDLINE_LINUX="$GRUB_CMDLINE_LINUX spectre_v2=on"
+
+## Disable Speculative Store Bypass.
+GRUB_CMDLINE_LINUX="$GRUB_CMDLINE_LINUX spec_store_bypass_disable=on"
+
+## Disable TSX, enable all mitigations for the TSX Async Abort
+## vulnerability and disable SMT.
+##
+## https://www.kernel.org/doc/html/latest/admin-guide/hw-vuln/tsx_async_abort.html
+GRUB_CMDLINE_LINUX="$GRUB_CMDLINE_LINUX tsx=off tsx_async_abort=full,nosmt"
+
+## Enable all mitigations for the MDS vulnerability and disable
+## SMT.
+##
+## https://www.kernel.org/doc/html/latest/admin-guide/hw-vuln/mds.html
+GRUB_CMDLINE_LINUX="$GRUB_CMDLINE_LINUX mds=full,nosmt"
+
+## Enable all mitigations for the L1TF vulnerability and disable SMT
+## and L1D flush runtime control.
+##
+## https://www.kernel.org/doc/html/latest/admin-guide/hw-vuln/l1tf.html
+GRUB_CMDLINE_LINUX="$GRUB_CMDLINE_LINUX l1tf=full,force"
+
+## Force disable SMT as it has caused numerous CPU vulnerabilities.
+##
+## https://forums.whonix.org/t/should-all-kernel-patches-for-cpu-bugs-be-unconditionally-enabled-vs-performance-vs-applicability/7647/17
+GRUB_CMDLINE_LINUX="$GRUB_CMDLINE_LINUX nosmt=force"
+
+## Mark all huge pages in the EPT as non-executable to mitigate iTLB multihit.
+##
+## https://www.kernel.org/doc/html/latest/admin-guide/hw-vuln/multihit.html#mitigation-control-on-the-kernel-command-line-and-kvm-module-parameter
+GRUB_CMDLINE_LINUX="$GRUB_CMDLINE_LINUX kvm.nx_huge_pages=force"

--- a/etc/default/grub.d/40_kernel_hardening.cfg
+++ b/etc/default/grub.d/40_kernel_hardening.cfg
@@ -36,27 +36,6 @@ GRUB_CMDLINE_LINUX="$GRUB_CMDLINE_LINUX mce=0"
 ## Enables Kernel Page Table Isolation which mitigates Meltdown and improves KASLR.
 GRUB_CMDLINE_LINUX="$GRUB_CMDLINE_LINUX pti=on"
 
-GRUB_CMDLINE_LINUX="$GRUB_CMDLINE_LINUX spectre_v2=on"
-
-GRUB_CMDLINE_LINUX="$GRUB_CMDLINE_LINUX spec_store_bypass_disable=on"
-
-GRUB_CMDLINE_LINUX="$GRUB_CMDLINE_LINUX tsx=off"
-
-GRUB_CMDLINE_LINUX="$GRUB_CMDLINE_LINUX tsx_async_abort=full,nosmt"
-
-## Enables all mitigations for the MDS vulnerability.
-## Disables smt which can be used to exploit the MDS vulnerability.
-GRUB_CMDLINE_LINUX="$GRUB_CMDLINE_LINUX mds=full,nosmt"
-
-## https://www.kernel.org/doc/html/latest/admin-guide/hw-vuln/l1tf.html
-GRUB_CMDLINE_LINUX="$GRUB_CMDLINE_LINUX l1tf=full,force"
-
-## https://forums.whonix.org/t/should-all-kernel-patches-for-cpu-bugs-be-unconditionally-enabled-vs-performance-vs-applicability/7647/17
-GRUB_CMDLINE_LINUX="$GRUB_CMDLINE_LINUX nosmt=force"
-
-## https://www.kernel.org/doc/html/latest/admin-guide/hw-vuln/multihit.html#mitigation-control-on-the-kernel-command-line-and-kvm-module-parameter
-GRUB_CMDLINE_LINUX="$GRUB_CMDLINE_LINUX kvm.nx_huge_pages=force"
-
 ## Vsyscalls are obsolete, are at fixed addresses and are a target for ROP.
 GRUB_CMDLINE_LINUX="$GRUB_CMDLINE_LINUX vsyscall=none"
 


### PR DESCRIPTION
Moves all the boot parameters into their own 40_cpu_mitigations.cfg file and improves the documentation.