### PR TITLE
Restrict loading line disciplines to CAP_SYS_MODULE

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -120,6 +120,8 @@ Description: enhances misc security settings
   * The kernel panics on oopses to prevent it from continuing to run a flawed
  process and to deter brute forcing.
  .
+  * Restricts loading line disciplines to CAP_SYS_MODULE.
+ .
  Improve Entropy Collection
  .
   * Load jitterentropy_rng kernel module.

--- a/etc/sysctl.d/30_security-misc.conf
+++ b/etc/sysctl.d/30_security-misc.conf
@@ -118,3 +118,8 @@ net.ipv4.conf.all.rp_filter=1
 net.ipv4.tcp_timestamps=0
 
 #### meta end
+
+## Restrict loading line disciplines to CAP_SYS_MODULE to prevent
+## unprivileged attackers from loading vulnerable line disciplines
+## with the TIOCSETD ioctl to exploit them.
+dev.tty.ldisc_autoload=0


### PR DESCRIPTION
An unprivileged user can load any line discipline they want with the TIOCSETD ioctl. This allows attackers to load ancient line disciplines with vulnerabilities to exploit them. This has been used in exploits before such as https://a13xp0p0v.github.io/2017/03/24/CVE-2017-2636.html

This restricts loading these to root (CAP_SYS_MODULE).

https://lkml.org/lkml/2019/4/15/890