### PR TITLE
Restrict the SysRq key

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -120,6 +120,9 @@ Description: enhances misc security settings
   * The kernel panics on oopses to prevent it from continuing to run a flawed
  process and to deter brute forcing.
  .
+  * Restricts the SysRq key so it can only be used for shutdowns and the
+  Secure Attention Key.
+ .
  Improve Entropy Collection
  .
   * Load jitterentropy_rng kernel module.

--- a/etc/sysctl.d/30_security-misc.conf
+++ b/etc/sysctl.d/30_security-misc.conf
@@ -118,3 +118,9 @@ net.ipv4.conf.all.rp_filter=1
 net.ipv4.tcp_timestamps=0
 
 #### meta end
+
+## Only allow the SysRq key to be used for shutdowns and the
+## Secure Attention Key (SAK).
+##
+## https://forums.whonix.org/t/sysrq-magic-sysrq-key/8079/
+kernel.sysrq=132


### PR DESCRIPTION
As per https://forums.whonix.org/t/sysrq-magic-sysrq-key/8079/

Restricts the SysRq key so it can only be used for shutdowns and SAK.

SAK = 4
shutdowns = 128
4 + 128 = 132 so we need to set `kernel.sysrq=132`.

https://www.kernel.org/doc/html/latest/admin-guide/sysrq.html#how-do-i-enable-the-magic-sysrq-key