### PR TITLE
Shred System.map files

### DIFF
--- a/usr/lib/security-misc/remove-system.map
+++ b/usr/lib/security-misc/remove-system.map
@@ -26,7 +26,7 @@ fi
 ## Removes the System.map files as they are only used for debugging or malware.
 for filename in ${system_map_location} ; do
    if [ -f "${filename}" ]; then
-      rm --verbose --force "${filename}"
+      shred --verbose --force --zero -u "${filename}"
    fi
 done
 


### PR DESCRIPTION
To prevent an attacker from recovering the deleted System.map files. This was discussed a while ago but forgotten about.