### PR TITLE
Restrict the userfaultfd() syscall to root

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -125,6 +125,8 @@ Description: enhances misc security settings
  .
   * Restricts loading line disciplines to CAP_SYS_MODULE.
  .
+  * Restricts the `userfaultfd()` syscall to root.
+ .
  Improve Entropy Collection
  .
   * Load jitterentropy_rng kernel module.

--- a/etc/sysctl.d/30_security-misc.conf
+++ b/etc/sysctl.d/30_security-misc.conf
@@ -133,3 +133,9 @@ kernel.sysrq=132
 ##
 ## https://lkml.org/lkml/2019/4/15/890
 dev.tty.ldisc_autoload=0
+
+## Restrict the userfaultfd() syscall to root as it can make heap sprays
+## easier.
+##
+## https://duasynt.com/blog/linux-kernel-heap-spray
+vm.unprivileged_userfaultfd=0


### PR DESCRIPTION
The `userfaultfd()` syscall adds a lot of attack surface and can make heap spraying easier.

https://duasynt.com/blog/linux-kernel-heap-spray

This restricts it to root so this type of attack cannot be done by unprivileged users.

This doesn't yet exist in the Whonix kernel version. It's just here for users of security-misc with newer kernels.

hardened-kernel takes a better approach and disables `CONFIG_USERFAULTFD` entirely.