### PR TITLE
remount-secure improvements

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -167,8 +167,9 @@ Description: enhances misc security settings
  .
  user restrictions:
  .
-  * remount `/home`, `/tmp`, `/dev/shm` and `/run` with `nosuid,nodev`
- (default) and `noexec` (opt-in). To disable this, run
+  * remount various directories with stricter mount options
+  (`nosuid`, `nodev` or `noexec`). `noexec` on some directories
+  is opt-in. To disable this, run
  `sudo touch /etc/remount-disable`. To opt-in `noexec`, run
  `sudo touch /etc/noexec` and reboot (easiest).
  Alternatively file `/usr/local/etc/remount-disable` or file

--- a/lib/systemd/system/remount-secure.service
+++ b/lib/systemd/system/remount-secure.service
@@ -2,7 +2,7 @@
 ## See the file COPYING for copying conditions.
 
 [Unit]
-Description=remount /home /tmp /dev/shm /run with nosuid,nodev (default) and noexec (opt-in)
+Description=remount various directories with stricter mount options
 Documentation=https://github.com/Whonix/security-misc
 
 DefaultDependencies=no

--- a/usr/lib/security-misc/remount-secure
+++ b/usr/lib/security-misc/remount-secure
@@ -93,7 +93,7 @@ _home() {
 
 _run() {
    ## https://lists.freedesktop.org/archives/systemd-devel/2015-February/028456.html
-   new_mount_options="nosuid,nodev${noexec_maybe}"
+   new_mount_options="nosuid,nodev,noexec"
    remount_secure "$@"
 }
 
@@ -104,6 +104,37 @@ _dev_shm() {
 
 _tmp() {
    new_mount_options="nosuid,nodev${noexec_maybe}"
+   remount_secure "$@"
+}
+
+_etc() {
+   # noexec here breaks LightDM.
+   new_mount_options="nosuid,nodev"
+   remount_secure "$@"
+}
+
+_usr() {
+   new_mount_options="nodev"
+   remount_secure "$@"
+}
+
+_bin() {
+   new_mount_options="nodev"
+   remount_secure "$@"
+}
+
+_sbin() {
+   new_mount_options="nodev"
+   remount_secure "$@"
+}
+
+_var() {
+   new_mount_options="nosuid,nodev${noexec_maybe}"
+   remount_secure "$@"
+}
+
+_boot() {
+   new_mount_options="nosuid,nodev,noexec"
    remount_secure "$@"
 }
 
@@ -123,6 +154,12 @@ main() {
    _run "$@"
    _dev_shm "$@"
    _tmp "$@"
+   _etc "$@"
+   _usr "$@"
+   _bin "$@"
+   _sbin "$@"
+   _var "$@"
+   _boot "$@"
    #_lib "$@"
    end "$@"
 }


### PR DESCRIPTION
* Adds `noexec` to /run regardless of /etc/noexec. This shouldn't break anything.
* Mounts /etc as `nosuid,nodev`. `noexec` breaks LightDM.
* Mounts /usr, /bin and /sbin as `nodev`.
* Mounts /var and /boot as `nosuid,nodev,noexec`.