### PR TITLE
Blacklist more modules (based on OpenSCAP for RHEL 8)

### DIFF
--- a/etc/modprobe.d/30_security-misc.conf
+++ b/etc/modprobe.d/30_security-misc.conf
@@ -44,6 +44,14 @@ install appletalk /bin/false
 install psnap /bin/false
 install p8023 /bin/false
 install p8022 /bin/false
+install can /bin/false
+install atm /bin/false
+
+# Disable uncommon filesystems to reduce attack surface
+install cramfs /bin/false
+install vfat /bin/false
+install squashfs /bin/false
+install udf /bin/false
 
 ## Blacklists the vivid kernel module as it's only required for
 ## testing and has been the cause of multiple vulnerabilities.


### PR DESCRIPTION
The modules blacklisted may  be debatable, but they aren't very commonly used so I think this shouldn't impact the average user. Open to feedback.

Sourced from: https://static.open-scap.org/ssg-guides/ssg-rhel8-guide-index.html
