### PR TITLE
Enable `vdso32=0`

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ configuration file.
   safety error detector which can identify heap out-of-bounds access, use-after-free,
   and invalid-free errors.
 
-- Provide the option to disable 32 bit vDSO mappings.
+- Disable 32-bit vDSO mappings as they are a legacy compatibility feature.
 
 - Provide the option to use kCFI as the default CFI implementation since it may be
   slightly more resilient to attacks that are able to write arbitrary executables

--- a/etc/default/grub.d/40_kernel_hardening.cfg
+++ b/etc/default/grub.d/40_kernel_hardening.cfg
@@ -136,13 +136,13 @@ GRUB_CMDLINE_LINUX="$GRUB_CMDLINE_LINUX debugfs=off"
 ##
 #GRUB_CMDLINE_LINUX="$GRUB_CMDLINE_LINUX kfence.sample_interval=100"
 
-## Disable x86 Virtual Dynamic Shared Object (vDSO) mappings.
+## Disable 32-bit Virtual Dynamic Shared Object (vDSO) mappings.
+## Legacy compatibility feature for superseded glibc versions.
 ##
-## https://en.wikipedia.org/wiki/VDSO
+## https://lore.kernel.org/lkml/20080409082927.BD59E26F992@magilla.localdomain/T/
+## https://lists.openwall.net/linux-kernel/2014/03/11/3
 ##
-## The use of 32 bit vDSO mappings is currently enabled.
-##
-#GRUB_CMDLINE_LINUX="$GRUB_CMDLINE_LINUX vdso32=0"
+GRUB_CMDLINE_LINUX="$GRUB_CMDLINE_LINUX vdso32=0"
 
 ## Switch (back) to using kCFI as the default Control Flow Integrity (CFI) implementation.
 ## The default implementation is FIneIBT as of Linux kernel 6.2.


### PR DESCRIPTION
Apply KSPP recommendation:
https://kspp.github.io/Recommended_Settings#x86_64-1

## Changes

Enable kernel parameter:
`vdso32=0`

## Mandatory Checklist

- [x] Legal agreements accepted. By contributing to this organisation, you acknowledge you have read, understood, and agree to be bound by these these agreements:

[Terms of Service](https://www.kicksecure.com/wiki/Terms_of_Service), [Privacy Policy](https://www.kicksecure.com/wiki/Privacy_Policy), [Cookie Policy](https://www.kicksecure.com/wiki/Cookie_Policy), [E-Sign Consent](https://www.kicksecure.com/wiki/E-Sign_Consent), [DMCA](https://www.kicksecure.com/wiki/DMCA), [Imprint](https://www.kicksecure.com/wiki/Imprint)

## Optional Checklist
The following items are optional but might be requested in certain cases.

- [x] I have tested it locally
- [x] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it