### PR TITLE
perf(permission-hardener): optimize string match

### DIFF
--- a/usr/bin/permission-hardener
+++ b/usr/bin/permission-hardener
@@ -256,8 +256,7 @@ check_nosuid_whitelist() {
   [[ " ${policy_exact_white_list[*]} " =~ " ${target_file} " ]] && return 1
 
   for match_white_list_entry in "${policy_match_white_list[@]:-}"; do
-    if safe_echo "${target_file}" \
-      | grep --quiet --fixed-strings -- "${match_white_list_entry}"; then
+    if [[ "${target_file}" == *"${match_white_list_entry}"* ]]; then
       return 1
     fi
   done


### PR DESCRIPTION
Replace subprocess grep calls with bash substring matching in `check_nosuid_whitelist` function. This eliminates ~10k unneeded subprocess spawns that were causing significant performance degradation.

In testing, it improves overall script execution speed by an order of magnitude:

Before patch:
```
$ sudo hyperfine -- './permission-hardener enable'
Benchmark 1: ./permission-hardener enable
  Time (mean ± σ):     11.906 s ±  0.974 s    [User: 3.639 s, System: 8.728 s]
  Range (min … max):   10.430 s … 14.090 s    10 runs
```

After patch:
```
$ sudo hyperfine -- './permission-hardener enable'
Benchmark 1: ./permission-hardener enable
  Time (mean ± σ):     802.8 ms ± 178.5 ms    [User: 283.0 ms, System: 471.9 ms]
  Range (min … max):   639.4 ms … 1092.3 ms    10 runs
```

## Mandatory Checklist

- [x] Legal agreements accepted. By contributing to this organisation, you acknowledge you have read, understood, and agree to be bound by these these agreements:

[Terms of Service](https://www.kicksecure.com/wiki/Terms_of_Service), [Privacy Policy](https://www.kicksecure.com/wiki/Privacy_Policy), [Cookie Policy](https://www.kicksecure.com/wiki/Cookie_Policy), [E-Sign Consent](https://www.kicksecure.com/wiki/E-Sign_Consent), [DMCA](https://www.kicksecure.com/wiki/DMCA), [Imprint](https://www.kicksecure.com/wiki/Imprint)