### PR TITLE
Enable `indirect_target_selection=force`

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,8 @@ CPU mitigations:
 
 - Register File Data Sampling (RFDS)
 
+- Indirect Target Selection (ITS)
+
 Boot parameters relating to kernel hardening, DMA mitigations, and entropy
 generation are outlined in the `/etc/default/grub.d/40_kernel_hardening.cfg`
 configuration file.

--- a/etc/default/grub.d/40_cpu_mitigations.cfg
+++ b/etc/default/grub.d/40_cpu_mitigations.cfg
@@ -187,3 +187,11 @@ GRUB_CMDLINE_LINUX="$GRUB_CMDLINE_LINUX gather_data_sampling=force"
 ## https://www.kernel.org/doc/html/latest/admin-guide/hw-vuln/reg-file-data-sampling.html
 ##
 GRUB_CMDLINE_LINUX="$GRUB_CMDLINE_LINUX reg_file_data_sampling=on"
+
+## Indirect Target Selection (ITS):
+## Mitigate the vulnerability by not allowing indirect branches in the lower half of the cacheline.
+## Currently affects Intel CPUs.
+##
+## https://www.kernel.org/doc/html/latest/admin-guide/hw-vuln/indirect-target-selection.html
+##
+GRUB_CMDLINE_LINUX="$GRUB_CMDLINE_LINUX indirect_target_selection=force"


### PR DESCRIPTION
This pull request enables a new CPU mitigation to a stricter level.

https://www.kernel.org/doc/html/latest/admin-guide/hw-vuln/indirect-target-selection.html

## Changes

Adds the `indirect_target_selection=force` kernel boot parameter.

## Mandatory Checklist

- [x] Legal agreements accepted. By contributing to this organisation, you acknowledge you have read, understood, and agree to be bound by these these agreements:

[Terms of Service](https://www.kicksecure.com/wiki/Terms_of_Service), [Privacy Policy](https://www.kicksecure.com/wiki/Privacy_Policy), [Cookie Policy](https://www.kicksecure.com/wiki/Cookie_Policy), [E-Sign Consent](https://www.kicksecure.com/wiki/E-Sign_Consent), [DMCA](https://www.kicksecure.com/wiki/DMCA), [Imprint](https://www.kicksecure.com/wiki/Imprint)

## Optional Checklist
The following items are optional but might be requested in certain cases.

- [x] I have tested it locally
- [x] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it