### PR TITLE
Enable `ia32_emulation=0`

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,8 +225,7 @@ Kernel space:
   since it may be slightly more resilient to attacks that are able to write
   arbitrary executables in memory.
 
-- Optional - Disable support for all x86 processes and syscalls (when using Linux kernel >= 6.7)
-  to reduce attack surface.
+- Disable support for all 32-bit x86 processes and syscalls to reduce attack surface.
 
 - Disable the EFI persistent storage feature which prevents the kernel from writing crash logs
   and other persistent data to either the UEFI variable storage or ACPI ERST backends.

--- a/etc/default/grub.d/40_kernel_hardening.cfg
+++ b/etc/default/grub.d/40_kernel_hardening.cfg
@@ -210,7 +210,7 @@ GRUB_CMDLINE_LINUX="$GRUB_CMDLINE_LINUX vdso32=0"
 ##
 #GRUB_CMDLINE_LINUX="$GRUB_CMDLINE_LINUX cfi=kcfi"
 
-## Disable support for x86 processes and syscalls.
+## Disable support for all 32-bit x86 processes and syscalls.
 ## Unconditionally disables IA32 emulation to substantially reduce attack surface.
 ##
 ## https://lore.kernel.org/all/20230623111409.3047467-7-nik.borisov@suse.com/
@@ -218,10 +218,7 @@ GRUB_CMDLINE_LINUX="$GRUB_CMDLINE_LINUX vdso32=0"
 ## KSPP=yes
 ## KSPP does not set CONFIG_COMPAT, CONFIG_IA32_EMULATION, CONFIG_X86_X32, CONFIG_X86_X32_ABI, and CONFIG_MODIFY_LDT_SYSCALL.
 ##
-## TODO: Debian 13 Trixie
-## Applicable when using Linux kernel >= 6.7 (retained here for future-proofing and completeness).
-##
-#GRUB_CMDLINE_LINUX="$GRUB_CMDLINE_LINUX ia32_emulation=0"
+GRUB_CMDLINE_LINUX="$GRUB_CMDLINE_LINUX ia32_emulation=0"
 
 ## Disable EFI persistent storage feature.
 ## Disable Error Record Serialization Table (ERST) support as a form of defense-in-depth.


### PR DESCRIPTION
This draft pull request blocks support for all 32-bit x86 processes and syscalls when on Linux kernel >= 6.7. 

Addresses and resolves https://github.com/Kicksecure/security-misc/issues/315/.

This permits full compliance with KSPP recommendations.

Note:
Should ONLY be considered after upgrading to Debian 13 (trixie). Changes have been submitted early to facilitate quicker feedback and review which would ideally enable more swift merging.

## Changes

Adds the `ia32_emulation=0` kernel boot parameter.

## Mandatory Checklist

- [x] Legal agreements accepted. By contributing to this organisation, you acknowledge you have read, understood, and agree to be bound by these these agreements:

[Terms of Service](https://www.kicksecure.com/wiki/Terms_of_Service), [Privacy Policy](https://www.kicksecure.com/wiki/Privacy_Policy), [Cookie Policy](https://www.kicksecure.com/wiki/Cookie_Policy), [E-Sign Consent](https://www.kicksecure.com/wiki/E-Sign_Consent), [DMCA](https://www.kicksecure.com/wiki/DMCA), [Imprint](https://www.kicksecure.com/wiki/Imprint)

## Optional Checklist
The following items are optional but might be requested in certain cases.

- [x] I have tested it locally
- [x] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it