### PR TITLE
Update SRSO docs

### DIFF
--- a/etc/default/grub.d/40_cpu_mitigations.cfg
+++ b/etc/default/grub.d/40_cpu_mitigations.cfg
@@ -167,7 +167,8 @@ GRUB_CMDLINE_LINUX="$GRUB_CMDLINE_LINUX kvm.mitigate_smt_rsb=1"
 ## https://www.kernel.org/doc/html/latest/admin-guide/hw-vuln/srso.html
 ##
 ## The default kernel setting will be utilized until provided sufficient evidence to modify.
-## Using "spec_rstack_overflow=ipbp" may provide stronger security at a greater performance impact.
+## Using "spec_rstack_overflow=ibpb" may provide superior protection to the default software-based approach.
+## The use of hardware barriers may be more effective while possibly incurring a greater performance loss.
 ##
 #GRUB_CMDLINE_LINUX="$GRUB_CMDLINE_LINUX spec_rstack_overflow=safe-ret"
 


### PR DESCRIPTION
This pull request changes adds very minor updates to the some details surrounding the SRSO mitigation. It also corrects a serious typo in the uncommented alternative.

See https://github.com/Kicksecure/security-misc/issues/177 where we decided to not change from the kernel default `spec_rstack_overflow=safe-ret` which is a software-only mitigation provided an appropriate microcode update has been applied.

While at that time we very seriously considered switching to using `spec_rstack_overflow=ibpb` which involves the use of hardware barriers after an appropriate microcode update has been applied, we chose not to go ahead with it due to insufficient evidence.

## Changes

There are no changes to the functionality of the codebase.

## Mandatory Checklist

- [x] Legal agreements accepted. By contributing to this organisation, you acknowledge you have read, understood, and agree to be bound by these these agreements:

[Terms of Service](https://www.kicksecure.com/wiki/Terms_of_Service), [Privacy Policy](https://www.kicksecure.com/wiki/Privacy_Policy), [Cookie Policy](https://www.kicksecure.com/wiki/Cookie_Policy), [E-Sign Consent](https://www.kicksecure.com/wiki/E-Sign_Consent), [DMCA](https://www.kicksecure.com/wiki/DMCA), [Imprint](https://www.kicksecure.com/wiki/Imprint)

## Optional Checklist
The following items are optional but might be requested in certain cases.

- [x] I have tested it locally
- [x] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it