### PR TITLE
Docs detailing the risks of allowing IPv6 RAs

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,8 +121,9 @@ configuration file and significant hardening is applied to a myriad of component
 - Disable source routing which allows users to redirect network traffic that
   can result in man-in-the-middle attacks.
 
-- Do not accept IPv6 router advertisements and solicitations.
-
+- Do not accept IPv6 router advertisements (RAs) and solicitations which can result
+  in both man-in-the-middle and denial-of-service attacks.
+  
 - Optional - Disable SACK and DSACK as they have historically been a known
   vector for exploitation.
 

--- a/usr/lib/sysctl.d/990-security-misc.conf#security-misc-shared
+++ b/usr/lib/sysctl.d/990-security-misc.conf#security-misc-shared
@@ -515,7 +515,15 @@ net.ipv4.icmp_ignore_bogus_error_responses=1
 net.ipv4.conf.*.accept_source_route=0
 net.ipv6.conf.*.accept_source_route=0
 
-## Do not accept IPv6 router advertisements and solicitations.
+## Do not accept IPv6 router advertisements (RAs) and solicitations.
+## RAs are unsecured and unauthenticated and any device on the local link can send and accept them without verification.
+## Malicious RAs can activate IPv6 connectivity on dormant hosts leading to unauthorized access.
+## Flooding the network with malicious RAs can lead to denial of service attacks.
+## Rogue RAs can lead to interception of all network traffic by setting the attacker's system as the default gateway.
+##
+## https://datatracker.ietf.org/doc/html/rfc6104
+## https://datatracker.ietf.org/doc/html/rfc6105
+## https://archive.conference.hitb.org/hitbsecconf2012kul/materials/D1T2%20-%20Marc%20Heuse%20-%20IPv6%20Insecurity%20Revolutions.pdf
 ##
 net.ipv6.conf.*.accept_ra=0
 


### PR DESCRIPTION
This pull request adds documentation details about the risks associated with IPv6 router advertisements (RAs).

## Changes

There are no changes to the functionality of the codebase.

## Mandatory Checklist

- [x] Legal agreements accepted. By contributing to this organisation, you acknowledge you have read, understood, and agree to be bound by these these agreements:

[Terms of Service](https://www.kicksecure.com/wiki/Terms_of_Service), [Privacy Policy](https://www.kicksecure.com/wiki/Privacy_Policy), [Cookie Policy](https://www.kicksecure.com/wiki/Cookie_Policy), [E-Sign Consent](https://www.kicksecure.com/wiki/E-Sign_Consent), [DMCA](https://www.kicksecure.com/wiki/DMCA), [Imprint](https://www.kicksecure.com/wiki/Imprint)

## Optional Checklist
The following items are optional but might be requested in certain cases.

- [x] I have tested it locally
- [x] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it