### PR TITLE
Add another method to disable 32-bit legacy vsyscalls

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,8 @@ configuration file and significant hardening is applied to a myriad of component
 
 - Disable asynchronous I/O as `io_uring` has been the source of numerous kernel exploits.
 
+- Disable 32-bit vDSO mappings as they are a legacy compatibility feature.
+
 #### User space
 
 - Disable the usage of `ptrace()` by all processes as it enables programs to inspect

--- a/etc/default/grub.d/40_kernel_hardening.cfg#security-misc-shared
+++ b/etc/default/grub.d/40_kernel_hardening.cfg#security-misc-shared
@@ -186,6 +186,8 @@ GRUB_CMDLINE_LINUX="$GRUB_CMDLINE_LINUX kfence.sample_interval=100"
 ## KSPP=yes
 ## KSPP sets the kernel parameter and does not set CONFIG_COMPAT_VDSO.
 ##
+## See /usr/lib/sysctl.d/990-security-misc.conf for another additional implementation.
+##
 GRUB_CMDLINE_LINUX="$GRUB_CMDLINE_LINUX vdso32=0"
 
 ## Switch (back) to using kCFI as the default Control Flow Integrity (CFI) implementation.

--- a/usr/lib/sysctl.d/990-security-misc.conf#security-misc-shared
+++ b/usr/lib/sysctl.d/990-security-misc.conf#security-misc-shared
@@ -20,6 +20,7 @@
 ## 5. Networking
 
 ## For detailed explanations of most of the selected commands, refer to:
+## https://www.kernel.org/doc/html/latest/admin-guide/sysctl/abi.html
 ## https://www.kernel.org/doc/html/latest/admin-guide/sysctl/kernel.html
 ## https://www.kernel.org/doc/html/latest/admin-guide/sysctl/fs.html
 ## https://www.kernel.org/doc/html/latest/admin-guide/sysctl/net.html
@@ -229,6 +230,19 @@ dev.tty.legacy_tiocsti=0
 ## https://forums.whonix.org/t/io-uring-security-vulnerabilties/16890
 ##
 kernel.io_uring_disabled=2
+
+## Disable 32-bit Virtual Dynamic Shared Object (vDSO) mappings.
+## Legacy compatibility feature for superseded glibc versions.
+##
+## https://lore.kernel.org/lkml/20080409082927.BD59E26F992@magilla.localdomain/T/
+## https://lists.openwall.net/linux-kernel/2014/03/11/3
+##
+## KSPP=yes
+## KSPP sets the kernel parameter and does not set CONFIG_COMPAT_VDSO.
+##
+## See /etc/default/grub.d/40_kernel_hardening.cfg for another additional implementation.
+##
+abi.vsyscall32=0
 
 ## 2. User Space:
 ##


### PR DESCRIPTION
This pull request adds another method to disable 32-bit legacy vsyscalls. This is done purely as a form of defence-in-depth on top of https://github.com/Kicksecure/security-misc/pull/260.

As per suggested in https://github.com/Kicksecure/security-misc/issues/329.

## Changes

Set `sysctl abi.vsyscall32=0`

## Mandatory Checklist

- [x] Legal agreements accepted. By contributing to this organisation, you acknowledge you have read, understood, and agree to be bound by these these agreements:

[Terms of Service](https://www.kicksecure.com/wiki/Terms_of_Service), [Privacy Policy](https://www.kicksecure.com/wiki/Privacy_Policy), [Cookie Policy](https://www.kicksecure.com/wiki/Cookie_Policy), [E-Sign Consent](https://www.kicksecure.com/wiki/E-Sign_Consent), [DMCA](https://www.kicksecure.com/wiki/DMCA), [Imprint](https://www.kicksecure.com/wiki/Imprint)

## Optional Checklist
The following items are optional but might be requested in certain cases.

- [x] I have tested it locally
- [x] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it