### PR TITLE
Restrict processes from modifying their own memory mappings

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,6 +238,9 @@ Kernel space:
 - Disable the EFI persistent storage feature which prevents the kernel from writing crash logs
   and other persistent data to either the UEFI variable storage or ACPI ERST backends.
 
+- Restrict processes from modifying their own memory mappings unless actively done via
+  `ptrace()` in order to limit self-modification which can trigger exploits.
+
 Direct memory access:
 
 - Enable strict IOMMU translation to protect against some DMA attacks via the use

--- a/etc/default/grub.d/40_kernel_hardening.cfg#security-misc-shared
+++ b/etc/default/grub.d/40_kernel_hardening.cfg#security-misc-shared
@@ -237,6 +237,19 @@ GRUB_CMDLINE_LINUX="$GRUB_CMDLINE_LINUX ia32_emulation=0"
 GRUB_CMDLINE_LINUX="$GRUB_CMDLINE_LINUX efi_pstore.pstore_disable=1"
 GRUB_CMDLINE_LINUX="$GRUB_CMDLINE_LINUX erst_disable"
 
+## Restrict processes from modifying their own memory mappings.
+## Prevents the use of FULL_FORCE by a processes unless via ptrace() for debugging.
+## Limit self-modification which can be used trigger race condition vulnerabilities.
+##
+## https://lore.kernel.org/lkml/20240712-vfs-procfs-ce7e6c7cf26b@brauner/
+## https://lwn.net/Articles/983169/
+## https://github.com/a13xp0p0v/kernel-hardening-checker/pull/201
+## https://github.com/Kicksecure/security-misc/issues/330
+##
+## Using "proc_mem.force_override=never" provides superior protection by never allowing overrides.
+##
+GRUB_CMDLINE_LINUX="$GRUB_CMDLINE_LINUX proc_mem.force_override=ptrace"
+
 ## 2. Direct Memory Access:
 ##
 ## https://madaidans-insecurities.github.io/guides/linux-hardening.html#dma-attacks


### PR DESCRIPTION
This pull request restrict processes from modifying their own memory mappings unless actively done via `ptrace()` in order to limit self-modification which can trigger exploits.

As per suggested in https://github.com/Kicksecure/security-misc/issues/330.

Note that this can be futher hardened by never allowing overrides using `proc_mem.force_override=never` instead.

## Changes

Set the `proc_mem.force_override=ptrace` kernel boot parameter.

## Mandatory Checklist

- [x] Legal agreements accepted. By contributing to this organisation, you acknowledge you have read, understood, and agree to be bound by these these agreements:

[Terms of Service](https://www.kicksecure.com/wiki/Terms_of_Service), [Privacy Policy](https://www.kicksecure.com/wiki/Privacy_Policy), [Cookie Policy](https://www.kicksecure.com/wiki/Cookie_Policy), [E-Sign Consent](https://www.kicksecure.com/wiki/E-Sign_Consent), [DMCA](https://www.kicksecure.com/wiki/DMCA), [Imprint](https://www.kicksecure.com/wiki/Imprint)

## Optional Checklist
The following items are optional but might be requested in certain cases.

- [x] I have tested it locally
- [x] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it