### PR TITLE
Prevent runaway privileged processes from writing to block devices `bdev_allow_write_mounted=0`

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,6 +238,9 @@ Kernel space:
 - Disable the EFI persistent storage feature which prevents the kernel from writing crash logs
   and other persistent data to either the UEFI variable storage or ACPI ERST backends.
 
+- Prevent runaway privileged processes from writing to block devices that are mounted by
+  filesystems to protect against filesystem corruption and kernel crashes.
+
 Direct memory access:
 
 - Enable strict IOMMU translation to protect against some DMA attacks via the use

--- a/etc/default/grub.d/40_kernel_hardening.cfg#security-misc-shared
+++ b/etc/default/grub.d/40_kernel_hardening.cfg#security-misc-shared
@@ -237,6 +237,18 @@ GRUB_CMDLINE_LINUX="$GRUB_CMDLINE_LINUX ia32_emulation=0"
 GRUB_CMDLINE_LINUX="$GRUB_CMDLINE_LINUX efi_pstore.pstore_disable=1"
 GRUB_CMDLINE_LINUX="$GRUB_CMDLINE_LINUX erst_disable"
 
+## Prevent processes from writing to block devices that are mounted by filesystems.
+## Enhances system stability and security by protecting against runaway privileged processes.
+## Allowing processes to write to the buffer cache can cause filesystem corruption and kernel crashes.
+## Does not prevent data modifications using direct SCSI commands or lower-level storage stack access.
+## May lead to breakages in certain limited scenarios.
+##
+## https://github.com/torvalds/linux/commit/ed5cc702d311c14b653323d76062b0294effa66e
+## https://lore.kernel.org/lkml/20240105-vfs-super-4092d802972c@brauner/
+## https://github.com/a13xp0p0v/kernel-hardening-checker/issues/186
+##
+GRUB_CMDLINE_LINUX="$GRUB_CMDLINE_LINUX bdev_allow_write_mounted=0"
+
 ## 2. Direct Memory Access:
 ##
 ## https://madaidans-insecurities.github.io/guides/linux-hardening.html#dma-attacks


### PR DESCRIPTION
This pull request prevents processes from writing to block devices that are mounted by filesystems to protect against runaway privileged processes causing filesystem corruption and kernel crashes.

Credit to the [kernel-hardening-checker](https://github.com/a13xp0p0v/kernel-hardening-checker) tool for bringing this to my attention.

Note this is also now only possible using Debian 13 and so should be included in our upcoming port.

## Changes

Set the `bdev_allow_write_mounted=0` kernel boot parameter.

## Mandatory Checklist

- [x] Legal agreements accepted. By contributing to this organisation, you acknowledge you have read, understood, and agree to be bound by these these agreements:

[Terms of Service](https://www.kicksecure.com/wiki/Terms_of_Service), [Privacy Policy](https://www.kicksecure.com/wiki/Privacy_Policy), [Cookie Policy](https://www.kicksecure.com/wiki/Cookie_Policy), [E-Sign Consent](https://www.kicksecure.com/wiki/E-Sign_Consent), [DMCA](https://www.kicksecure.com/wiki/DMCA), [Imprint](https://www.kicksecure.com/wiki/Imprint)

## Optional Checklist
The following items are optional but might be requested in certain cases.

- [x] I have tested it locally
- [x] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it