### PR TITLE
Disable reuse of `TIME_WAIT` sockets

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,9 @@ configuration file and significant hardening is applied to a myriad of component
 
 - Disable TCP timestamps as they can allow detecting the system time.
 
+- Disable reuse of `TIME_WAIT` sockets for new outgoing connections as the above
+  setting disables TCP timestamps.
+
 - Optional - Log packets with impossible source or destination addresses to
   enable further inspection and analysis.
 

--- a/usr/lib/sysctl.d/990-security-misc.conf#security-misc-shared
+++ b/usr/lib/sysctl.d/990-security-misc.conf#security-misc-shared
@@ -565,6 +565,16 @@ net.ipv6.conf.*.accept_ra=0
 ##
 net.ipv4.tcp_timestamps=0
 
+## Disable reuse of TIME_WAIT sockets for new outgoing connections.
+## The safety of reusing of TIME_WAIT sockets requires enabling TCP timestamps.
+## The kernel uses timestamps to verify a new connection is not a duplicate segment from an older connection.
+## Hence TIME-WAIT sockets should wait the full timeout period before being made available again.
+## Can lead to port exhaustion on high-traffic networks with numerous short-lived connections.
+##
+## https://vincent.bernat.ch/en/blog/2014-tcp-time-wait-state-linux
+##
+net.ipv4.tcp_tw_reuse=0
+
 ## Enable logging of packets with impossible source or destination addresses.
 ## Martian and unroutable packets may be used for malicious purposes.
 ## Recommended to keep a (kernel dmesg) log of these to identify suspicious packets.


### PR DESCRIPTION
This pull request disable reuse of `TIME_WAIT` sockets for new outgoing connections as the safety of this feature is reliant on TCP timestamps which we have disabled.

TCP timestamps have been disabled since 01/04/2016 as per https://github.com/Kicksecure/security-misc/pull/1, that is, the very first pull request or issue on GitHub.

Note that this setting currently defaults to `net.ipv4.tcp_tw_reuse=2` which permits reuse only for loopback connections. This is still broken as there are no associated timestamps to ensure the new connection is not a duplicate segment from an older connection.

## Changes

Set `sysctl net.ipv4.tcp_tw_reuse=0` setting.

## Mandatory Checklist

- [x] Legal agreements accepted. By contributing to this organisation, you acknowledge you have read, understood, and agree to be bound by these these agreements:

[Terms of Service](https://www.kicksecure.com/wiki/Terms_of_Service), [Privacy Policy](https://www.kicksecure.com/wiki/Privacy_Policy), [Cookie Policy](https://www.kicksecure.com/wiki/Cookie_Policy), [E-Sign Consent](https://www.kicksecure.com/wiki/E-Sign_Consent), [DMCA](https://www.kicksecure.com/wiki/DMCA), [Imprint](https://www.kicksecure.com/wiki/Imprint)

## Optional Checklist
The following items are optional but might be requested in certain cases.

- [x] I have tested it locally
- [x] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it