### PR TITLE
Re-enable the Logging of Martian Packets

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,8 +132,8 @@ configuration file and significant hardening is applied to a myriad of component
 
 - Disable TCP timestamps as they can allow detecting the system time.
 
-- Optional - Log packets with impossible source or destination addresses to
-  enable further inspection and analysis.
+- Log packets with impossible source or destination addresses to enable further
+  inspection and analysis.
 
 - Optional - Enable IPv6 Privacy Extensions.
 

--- a/usr/lib/sysctl.d/990-security-misc.conf#security-misc-shared
+++ b/usr/lib/sysctl.d/990-security-misc.conf#security-misc-shared
@@ -576,7 +576,7 @@ net.ipv4.tcp_timestamps=0
 ##
 ## The logging of martian packets is currently disabled.
 ##
-#net.ipv4.conf.*.log_martians=1
+net.ipv4.conf.*.log_martians=1
 
 ## Enable IPv6 Privacy Extensions to prefer temporary addresses over public addresses.
 ## The temporary/privacy address is used as the source for all outgoing traffic.


### PR DESCRIPTION
This pull request re-enables the logging of martian packets

Currently a draft PR as per https://github.com/Kicksecure/security-misc/issues/214#issuecomment-3509646182.

## Changes

Re-sets `sysctl net.ipv4.conf.*.log_martians=1` setting.

## Mandatory Checklist

- [x] Legal agreements accepted. By contributing to this organisation, you acknowledge you have read, understood, and agree to be bound by these these agreements:

[Terms of Service](https://www.kicksecure.com/wiki/Terms_of_Service), [Privacy Policy](https://www.kicksecure.com/wiki/Privacy_Policy), [Cookie Policy](https://www.kicksecure.com/wiki/Cookie_Policy), [E-Sign Consent](https://www.kicksecure.com/wiki/E-Sign_Consent), [DMCA](https://www.kicksecure.com/wiki/DMCA), [Imprint](https://www.kicksecure.com/wiki/Imprint)

## Optional Checklist
The following items are optional but might be requested in certain cases.

- [x] I have tested it locally
- [x] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it