### PR TITLE
Provide the option to panic upon the kernel becoming tainted

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,8 +237,9 @@ Kernel space:
   risk and impact of denial-of-service attacks and both cold and warm boot attacks.
 
 - Optional - Force the kernel to immediately panic if it becomes tainted. Some reasons include
-  upon using out of specification hardware, bad page states, severe firmware bugs. It can also
-  include the loading of proprietary, out-of-tree, and unsigned modules.
+  upon using out of specification hardware, bad page states, ACPI tables being overridden,
+  severe firmware bugs, in-kernel tests run, or mutating debug operations. It can also
+  include the loading of proprietary or out-of-tree modules.
 
 - Prevent sensitive kernel information leaks in the console during boot.
 

--- a/etc/default/grub.d/40_kernel_hardening.cfg#security-misc-shared
+++ b/etc/default/grub.d/40_kernel_hardening.cfg#security-misc-shared
@@ -169,10 +169,11 @@ GRUB_CMDLINE_LINUX="$GRUB_CMDLINE_LINUX debugfs=off"
 ## Some example combinations are shown below.
 ## S - Panic on using out of specification hardware: 4 = 0x4.
 ## B - On the above and bad page faults or some unexpected page flags: 36 = 0x24.
-## I - On the above and severe firmware bugs: 2084 = 0x824.
-## N - On the above and if an in-kernel test has been run: 264228 = 0x40824.
-## J - On the above and if userspace used a mutating debug operation: 788516 = 0xC0824.
-## G/P, O, E - On the above and the loading of proprietary, out-of-tree, or unsigned modules: 800805 = 0xC3825.
+## A - On the above and ACPI tables are overridden by users: 292 = 0x124.
+## I - On the above and severe firmware bugs: 2340 = 0x924.
+## N - On the above and in-kernel tests have been run: 264484 = 0x40924.
+## J - On the above and userspace has used a mutating debug operation: 788772 = 0xC0924.
+## G/P, O - On the above and the loading of proprietary or out-of-tree modules: 792869 = 0xC1925.
 ## All must first be tested to ensure there are no pre-existing issues on user hardware.
 ## After confirming stability this enforces strict user-defined kernel operation and security at runtime.
 ##
@@ -183,7 +184,7 @@ GRUB_CMDLINE_LINUX="$GRUB_CMDLINE_LINUX debugfs=off"
 ##
 ## Note that this must be used with panic=-1 for it to function as intended.
 ##
-#GRUB_CMDLINE_LINUX="$GRUB_CMDLINE_LINUX panic_on_taint=0xC0824
+#GRUB_CMDLINE_LINUX="$GRUB_CMDLINE_LINUX panic_on_taint=0xC0924
 
 ## Prevent sensitive kernel information leaks in the console during boot.
 ## Must be used in combination with the kernel.printk sysctl.


### PR DESCRIPTION
This pull request provides the option to panic upon the kernel becoming tainted.

After first testing, this can be used to enforce strict user-defined kernel operation and security at runtime. The exact subset selected is up to the user but in the presented default I have included panicking upon using out of specification hardware, bad page states, severe firmware bugs, and kernel live patching.

Given this is a comment-only PR, I do not see anything controversial with this as all it does is tell users that such a feature is available if they are first willing to test there are no problems prior to them being used as hardening features.

Please see references inside the commits and also the kernel [docs](https://www.kernel.org/doc/html/latest/admin-guide/tainted-kernels.html).

## Changes

There are no changes to the functionality of the codebase.

Provide the disabled by default option:
```
panic_on_taint=0x8824
```

## Mandatory Checklist

- [x] Legal agreements accepted. By contributing to this organisation, you acknowledge you have read, understood, and agree to be bound by these these agreements:

[Terms of Service](https://www.kicksecure.com/wiki/Terms_of_Service), [Privacy Policy](https://www.kicksecure.com/wiki/Privacy_Policy), [Cookie Policy](https://www.kicksecure.com/wiki/Cookie_Policy), [E-Sign Consent](https://www.kicksecure.com/wiki/E-Sign_Consent), [DMCA](https://www.kicksecure.com/wiki/DMCA), [Imprint](https://www.kicksecure.com/wiki/Imprint)

## Optional Checklist
The following items are optional but might be requested in certain cases.

- [x] I have tested it locally
- [x] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it