### PR TITLE
Provide the option to enable AMD SEV-ES and SEV-SNP

### DIFF
--- a/etc/default/grub.d/40_kernel_hardening.cfg#security-misc-shared
+++ b/etc/default/grub.d/40_kernel_hardening.cfg#security-misc-shared
@@ -261,7 +261,7 @@ GRUB_CMDLINE_LINUX="$GRUB_CMDLINE_LINUX erst_disable"
 ## Both require a compatible AMD CPU and support for SME to first be enabled in the BIOS/UEFI.
 ## Likely unavailable in consumer-grade AMD CPUs where Transparent SME (TSME) can be enabled in the BIOS/UEFI to achieve SME.
 ## Note the corresponding Intel Total Memory Encryption (TME) can also be enabled via the BIOS/UEFI.
-## May cause boot failure on certain hardware with incompatible DMA masks.
+## May cause boot failure on certain hardware with incompatible DMA masks especially if IOMMU is disabled.
 ##
 ## https://www.kernel.org/doc/html/next/x86/amd-memory-encryption.html
 ## https://www.kernel.org/doc/html/latest/virt/kvm/x86/amd-memory-encryption.html
@@ -269,9 +269,11 @@ GRUB_CMDLINE_LINUX="$GRUB_CMDLINE_LINUX erst_disable"
 ## https://docs.amd.com/v/u/en-US/SEV-SNP-strengthening-vm-isolation-with-integrity-protection-and-more
 ## https://github.com/AMDESE/AMDSEV
 ## https://en.wikichip.org/wiki/x86/sme
+## https://lore.kernel.org/all/YWRgN63FOrQGO8jS@zn.tnic/
 ## https://lore.kernel.org/lkml/YWvy9bSRaC+m1sV+@zn.tnic/T/#m01bcb37040b6b0d119d385d9a34b9c7ac4ce5f84
 ## https://mricher.fr/post/amd-memory-encryption/
 ## https://www.kicksecure.com/wiki/Dev/confidential_computing#AMD
+## https://github.com/secureblue/secureblue/pull/1631#issuecomment-3655501478
 ## https://forums.whonix.org/t/enable-secure-memory-encryption-sme-kernel-parameter-mem-encrypt-by-default/10393
 ##
 #GRUB_CMDLINE_LINUX="$GRUB_CMDLINE_LINUX mem_encrypt=on"


### PR DESCRIPTION
This pull request provides the options to enable two extensions of AMD Secure Encrypted Virtualization (SEV):
- SEV-ES (Encrypted State) extends SEV by encrypting each guests virtual CPU register state during VM exits, and
- SEV-SNP (Secure Nested Paging) extends SEV by activating hardware-level memory integrity.

As per suggested in https://github.com/Kicksecure/security-misc/pull/338#issuecomment-3588000749 by @ArrayBolt3.

## Changes

There are no changes to the functionality of the codebase.

Provide the disabled by default options:
```
kvm_amd.sev_es=1
kvm_amd.sev_snp=1
```

## Mandatory Checklist

- [x] Legal agreements accepted. By contributing to this organisation, you acknowledge you have read, understood, and agree to be bound by these these agreements:

[Terms of Service](https://www.kicksecure.com/wiki/Terms_of_Service), [Privacy Policy](https://www.kicksecure.com/wiki/Privacy_Policy), [Cookie Policy](https://www.kicksecure.com/wiki/Cookie_Policy), [E-Sign Consent](https://www.kicksecure.com/wiki/E-Sign_Consent), [DMCA](https://www.kicksecure.com/wiki/DMCA), [Imprint](https://www.kicksecure.com/wiki/Imprint)

## Optional Checklist
The following items are optional but might be requested in certain cases.

- [x] I have tested it locally
- [x] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it