### PR TITLE
Enable SME and SEV in supported AMD processors

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,8 +267,8 @@ Kernel space:
 - Prevent runaway privileged processes from writing to block devices that are mounted by
   filesystems to protect against filesystem corruption and kernel crashes.
 
-- Optional - On compatible AMD CPUs enable Secure Memory Encryption (SME) to protect against
-  cold boot attacks and Secure Encrypted Virtualization (SEV) for further guest memory isolation.
+- On compatible AMD CPUs enable Secure Memory Encryption (SME) to protect against cold boot
+  attacks and Secure Encrypted Virtualization (SEV) for further guest memory isolation.
 
 Direct memory access:
 

--- a/etc/default/grub.d/40_kernel_hardening.cfg#security-misc-shared
+++ b/etc/default/grub.d/40_kernel_hardening.cfg#security-misc-shared
@@ -316,10 +316,10 @@ GRUB_CMDLINE_LINUX="$GRUB_CMDLINE_LINUX bdev_allow_write_mounted=0"
 ## https://github.com/secureblue/secureblue/pull/1631#issuecomment-3655501478
 ## https://forums.whonix.org/t/enable-secure-memory-encryption-sme-kernel-parameter-mem-encrypt-by-default/10393
 ##
-#GRUB_CMDLINE_LINUX="$GRUB_CMDLINE_LINUX mem_encrypt=on"
-#GRUB_CMDLINE_LINUX="$GRUB_CMDLINE_LINUX kvm_amd.sev=1"
-#GRUB_CMDLINE_LINUX="$GRUB_CMDLINE_LINUX kvm_amd.sev_es=1"
-#GRUB_CMDLINE_LINUX="$GRUB_CMDLINE_LINUX kvm_amd.sev_snp=1"
+GRUB_CMDLINE_LINUX="$GRUB_CMDLINE_LINUX mem_encrypt=on"
+GRUB_CMDLINE_LINUX="$GRUB_CMDLINE_LINUX kvm_amd.sev=1"
+GRUB_CMDLINE_LINUX="$GRUB_CMDLINE_LINUX kvm_amd.sev_es=1"
+GRUB_CMDLINE_LINUX="$GRUB_CMDLINE_LINUX kvm_amd.sev_snp=1"
 
 ## 2. Direct Memory Access:
 ##

--- a/etc/default/grub.d/40_kernel_hardening.cfg#security-misc-shared
+++ b/etc/default/grub.d/40_kernel_hardening.cfg#security-misc-shared
@@ -307,6 +307,7 @@ GRUB_CMDLINE_LINUX="$GRUB_CMDLINE_LINUX bdev_allow_write_mounted=0"
 ## https://docs.kernel.org/virt/kvm/x86/amd-memory-encryption.html
 ## https://docs.amd.com/v/u/en-US/memory-encryption-white-paper
 ## https://docs.amd.com/v/u/en-US/SEV-SNP-strengthening-vm-isolation-with-integrity-protection-and-more
+## https://docs.amd.com/v/u/en-US/24593_3.43
 ## https://github.com/AMDESE/AMDSEV
 ## https://en.wikichip.org/wiki/x86/sme
 ## https://lore.kernel.org/all/YWRgN63FOrQGO8jS@zn.tnic/


### PR DESCRIPTION
This pull request enables SME and SEV in supported AMD processors.

As per discussed in https://github.com/Kicksecure/security-misc/pull/338 and https://github.com/Kicksecure/security-misc/pull/341.

This has also been suggested by me and approved in https://github.com/secureblue/secureblue/pull/1631.

## Changes
Sets the following kernel boot parameters:
```
mem_encrypt=on
kvm_amd.sev=1
vm_amd.sev_es=1
vm_amd.sev_snp=1
```
## Mandatory Checklist

- [x] Legal agreements accepted. By contributing to this organisation, you acknowledge you have read, understood, and agree to be bound by these these agreements:

[Terms of Service](https://www.kicksecure.com/wiki/Terms_of_Service), [Privacy Policy](https://www.kicksecure.com/wiki/Privacy_Policy), [Cookie Policy](https://www.kicksecure.com/wiki/Cookie_Policy), [E-Sign Consent](https://www.kicksecure.com/wiki/E-Sign_Consent), [DMCA](https://www.kicksecure.com/wiki/DMCA), [Imprint](https://www.kicksecure.com/wiki/Imprint)

## Optional Checklist
The following items are optional but might be requested in certain cases.

- [x] I have tested it locally
- [x] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it