### PR TITLE
Fix shell quoting and add username validation

### DIFF
--- a/usr/libexec/security-misc/build-fm-shim-backend#security-misc-shared
+++ b/usr/libexec/security-misc/build-fm-shim-backend#security-misc-shared
@@ -46,12 +46,12 @@ gcc_hardening_options+=(
 
 gcc \
   -g \
-  $(pkg-config --cflags dbus-1) \
-  $(pkg-config --cflags libsystemd) \
+  "$(pkg-config --cflags dbus-1)" \
+  "$(pkg-config --cflags libsystemd)" \
   /usr/src/security-misc/fm-shim-backend.c \
   -o /usr/bin/fm-shim-backend \
-  $(pkg-config --libs dbus-1) \
-  $(pkg-config --libs libsystemd) \
+  "$(pkg-config --libs dbus-1)" \
+  "$(pkg-config --libs libsystemd)" \
   "${gcc_hardening_options[@]}" \
   || {
     printf "%s\n" 'Could not compile fm-shim-backend executable!'

--- a/usr/libexec/security-misc/virusforget#security-misc-shared
+++ b/usr/libexec/security-misc/virusforget#security-misc-shared
@@ -85,6 +85,11 @@ parse_cmd_options() {
       echo "ERROR: must set --user username" >&2
       exit 1
    fi
+
+   if [[ ! "$user_name" =~ ^[a-zA-Z0-9._-]+$ ]]; then
+      echo "ERROR: Invalid username format. Only alphanumeric characters, dots, underscores, and hyphens are allowed." >&2
+      exit 1
+   fi
 }
 
 variables() {


### PR DESCRIPTION
This PR addresses two security and robustness improvements in the security-misc scripts.

**Summary of Changes:**
- Fixed improper shell variable expansion in the fm-shim-backend build script
- Added input validation for usernames in the virusforget script

**Key Changes:**
- **build-fm-shim-backend**: Wrapped all `pkg-config` command substitutions in double quotes to prevent word splitting and glob expansion of compiler flags. This ensures flags containing spaces or special characters are properly preserved as single arguments.
- **virusforget**: Added username format validation using a regex pattern that only allows alphanumeric characters, dots, underscores, and hyphens. Invalid usernames now trigger an error message and exit before processing.

**Implementation Details:**
The username validation regex `^[a-zA-Z0-9._-]+$` ensures that only safe characters are accepted, reducing the risk of injection attacks or unexpected behavior when the username is used in subsequent operations. The validation occurs immediately after the username is set, providing early error detection.

https://claude.ai/code/session_01AuD3r15oCtTSHus57Xjmzy