### PR TITLE
Make bdev_allow_write_mounted kernel parameter optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,8 +273,9 @@ Kernel space:
 - Restrict processes from modifying their own memory mappings unless actively done via
   `ptrace()` for debugging in order to limit self-modification which can trigger exploits.
 
-- Prevent runaway privileged processes from writing to block devices that are mounted by
-  filesystems to protect against filesystem corruption and kernel crashes.
+- Optional - Prevent runaway privileged processes from writing to block devices that are mounted by
+  filesystems to protect against filesystem corruption and kernel crashes. May cause breakages with
+  disk management operations such as disk resizing and VDI compaction in virtual machines.
 
 - Optional - On compatible AMD CPUs enable Secure Memory Encryption (SME) to protect against
   cold boot attacks and Secure Encrypted Virtualization (SEV) for further guest memory isolation.

--- a/etc/default/grub.d/40_kernel_hardening.cfg#security-misc-shared
+++ b/etc/default/grub.d/40_kernel_hardening.cfg#security-misc-shared
@@ -290,7 +290,12 @@ GRUB_CMDLINE_LINUX="$GRUB_CMDLINE_LINUX proc_mem.force_override=ptrace"
 ## https://lore.kernel.org/lkml/20240105-vfs-super-4092d802972c@brauner/
 ## https://github.com/a13xp0p0v/kernel-hardening-checker/issues/186
 ##
-GRUB_CMDLINE_LINUX="$GRUB_CMDLINE_LINUX bdev_allow_write_mounted=0"
+## https://github.com/Kicksecure/security-misc/pull/334
+## https://forums.whonix.org/t/kernel-hardening-security-misc/7296/609
+## https://forums.whonix.org/t/how-to-compress-and-prevent-vdi-from-ballooning-after-each-update-deleting-large-files/22675/9
+## https://forums.kicksecure.com/t/resizing-disk-for-guest-in-kvm/1657
+##
+#GRUB_CMDLINE_LINUX="$GRUB_CMDLINE_LINUX bdev_allow_write_mounted=0"
 
 ## Enable AMD Secure Memory Encryption (SME) and Secure Encrypted Virtualization (SEV).
 ## SME encrypts memory with a single key at the kernel level to protect against cold boot attacks.


### PR DESCRIPTION
## Summary
This change makes the `bdev_allow_write_mounted=0` kernel hardening parameter optional by commenting it out in the default GRUB configuration, while updating documentation to reflect potential compatibility issues.

## Key Changes
- Commented out the `bdev_allow_write_mounted=0` kernel parameter in `etc/default/grub.d/40_kernel_hardening.cfg`
- Added references to related discussions documenting issues with disk management operations
- Updated README.md to clarify that this is an optional hardening measure
- Added documentation of known breakages with disk resizing and VDI compaction in virtual machines

## Details
The `bdev_allow_write_mounted=0` parameter prevents privileged processes from writing to mounted block devices, protecting against filesystem corruption and kernel crashes. However, this parameter can interfere with legitimate disk management operations such as:
- Disk resizing in virtual machines
- VDI compaction operations

By making this parameter optional (disabled by default), users can choose to enable it based on their security requirements and use case compatibility. The documentation now clearly indicates this is an optional hardening feature with potential operational trade-offs.

* https://github.com/Kicksecure/security-misc/pull/334

https://claude.ai/code/session_01Cd9ka8sC7zLUvB31V4kxMk