### PR TITLE
fix(virusforget): correct --clean abort and --user validation

### DIFF
--- a/usr/libexec/security-misc/virusforget#security-misc-shared
+++ b/usr/libexec/security-misc/virusforget#security-misc-shared
@@ -297,6 +297,13 @@ unexpected_file() {
 }
 
 restore_file() {
+   ## An extraneous file has no baseline backup to restore from; the caller
+   ## has already removed it, which is the correct action. Return early so the
+   ## 'cp' below does not fail on the missing backup and abort the entire
+   ## '--clean' run (via 'set -e') on the first extraneous file encountered.
+   if [ ! -e "$full_path_backup" ]; then
+      return 0
+   fi
    if [ "$test_mode" = "true" ]; then
       echo "Simulate restoring file... $full_path_original" >&2
       echo cp --no-dereference --archive "$full_path_backup" "$full_path_original"

--- a/usr/libexec/security-misc/virusforget#security-misc-shared
+++ b/usr/libexec/security-misc/virusforget#security-misc-shared
@@ -86,7 +86,8 @@ parse_cmd_options() {
       exit 1
    fi
    if ! id -u "$user_name" >/dev/null 2>&1; then
-     echo "ERROR: User '$user_name' does not appear to exist!"
+      echo "ERROR: User '$user_name' does not appear to exist!" >&2
+      exit 1
    fi
 }
 


### PR DESCRIPTION
## Summary

`virusforget --clean` aborts partway through on exactly the input it exists
to remove, and an invalid `--user` is detected but not acted on. These are
two small, independent error-handling fixes to `usr/libexec/security-misc/virusforget`.

## Changes

- **Guard `restore_file` against a missing backup.** Root cause: an
  extraneous file (present in `$HOME`, absent from the committed backup) is
  deleted and then unconditionally passed to `restore_file`, which runs `cp`
  from a backup path that does not exist. Under `set -e` this aborts the
  entire `--clean` run on the first such file, leaving the system partially
  cleaned. The fix returns early when no backup exists — deleting the
  extraneous file is the correct action and is already done by the caller,
  which keeps a forensic copy under `dangerous/`.
- **Exit when `--user` does not exist.** The nonexistent-user branch printed
  a warning to stdout but, unlike every sibling validation branch, neither
  wrote to stderr nor exited, so a mistyped `--user` proceeded against a
  bogus `/home/<user>`. It now writes to stderr and `exit 1`.

## Testing

- `bash -n usr/libexec/security-misc/virusforget` — no syntax errors.
- Manually traced both walk paths (the direct `process_files` call chain and
  the `process_folders` `find | while` subshell). Because the script uses
  `set -e` without `errtrace`, the subshell path aborts via `set -e`
  propagation on the failed pipe rather than the `ERR` trap, but both paths
  stop on the first extraneous file pre-fix and complete after the guard.

## Notes for reviewers

- The two commits are independent and can be reviewed/reverted separately.
- The `restore_file` guard is transparent to its other two callers
  (missing-file and modified-file), which always have a backup present.
- Behavior-only diff (9 insertions, 1 deletion); no reformatting.
