### PR TITLE
fix(ensure-shutdown): apply timeout default under nounset

### DIFF
--- a/usr/libexec/security-misc/ensure-shutdown#security-misc-shared
+++ b/usr/libexec/security-misc/ensure-shutdown#security-misc-shared
@@ -20,7 +20,7 @@ for config_file in /etc/security-misc/emerg-shutdown/*.conf /usr/local/etc/secur
     source "${config_file}"
   fi
 done
-if [ -z "${ENSURE_SHUTDOWN_TIMEOUT}" ] \
+if [ -z "${ENSURE_SHUTDOWN_TIMEOUT:-}" ] \
   || ! is_whole_number "${ENSURE_SHUTDOWN_TIMEOUT}"; then
   ENSURE_SHUTDOWN_TIMEOUT=30;
 fi


### PR DESCRIPTION
## Summary

`ensure-shutdown`'s built-in `ENSURE_SHUTDOWN_TIMEOUT` fallback is unreachable under `set -o nounset`. When no config file assigns the variable, the guard aborts the script instead of defaulting to 30, so the forced-shutdown watchdog (`ExecStart`) never starts.

## Changes

- Root cause: the guard tests `[ -z "${ENSURE_SHUTDOWN_TIMEOUT}" ]` with no `:-` default. Under `nounset`, expanding the unset variable raises `unbound variable` and exits before the `=30` fallback can run. Add the `:-` default (`${ENSURE_SHUTDOWN_TIMEOUT:-}`) so the guard evaluates and applies the default. The `is_whole_number` call on the next line is unchanged — it is only reached when the variable is set.

## Testing

- `bash -n` on the patched script — OK.
- Minimal repro under `set -o nounset`, variable unset: pre-fix `[ -z "${VAR}" ]` → `VAR: unbound variable`, exit 127, fallback never runs; post-fix `[ -z "${VAR:-}" ]` → prints the fallback branch, exit 0.

## Notes for reviewers

- Not a default-install regression: the shipped `etc/security-misc/emerg-shutdown/30_security_misc.conf` sets `ENSURE_SHUTDOWN_TIMEOUT=30`, so this only bites a config that no longer assigns it (e.g. an admin edits the conffile trusting the script's advertised default). The sibling `emerg-shutdown` wrapper avoids the same trap by pre-initializing its config variables before sourcing.
