### PR TITLE
fix(permission-hardener): prevent whitelist fail-open and hardlink abort

### DIFF
--- a/usr/bin/permission-hardener#security-misc-shared
+++ b/usr/bin/permission-hardener#security-misc-shared
@@ -280,7 +280,7 @@ check_nosuid_whitelist() {
   ## literal matching is intentional here too
   [[ " ${policy_exact_white_list[*]} " =~ " ${target_file} " ]] && return 1
 
-  for match_white_list_entry in "${policy_match_white_list[@]:-}"; do
+  for match_white_list_entry in ${policy_match_white_list[@]+"${policy_match_white_list[@]}"}; do
     if [[ "${target_file}" == *"${match_white_list_entry}"* ]]; then
       return 1
     fi

--- a/usr/bin/permission-hardener#security-misc-shared
+++ b/usr/bin/permission-hardener#security-misc-shared
@@ -188,7 +188,11 @@ File name: '${file_name}'
 File name from stat: '${file_name_from_stat}'
 line: '${processed_config_line}'
 " >&2
-      return 1
+      existing_mode=''
+      existing_owner=''
+      existing_group=''
+      file_name_from_stat=''
+      return 0
     fi
   fi
 


### PR DESCRIPTION
## Summary

Two independent defects in `permission-hardener`'s SUID/SGID hardening
path each cause hardening to be silently skipped rather than applied —
the worst failure mode for a hardening tool, since both exit 0 with no
obvious signal. Both are one-spot fixes in `check_nosuid_whitelist` and
`output_stat`.

## Changes

- **Empty `matchwhitelist` no longer whitelists every file.** Root
  cause: `check_nosuid_whitelist` looped over
  `"${policy_match_white_list[@]:-}"`; under `set -o nounset` the `:-`
  expands an empty array to one empty-string element, and
  `[[ "$target" == *""* ]]` matches everything, so the function returned
  "whitelisted" for every file and both `|| continue` callers skipped
  all hardening. Now expands with `${arr[@]+"${arr[@]}"}` (no elements
  when empty, nounset-safe).
- **Hardlinked files are skipped instead of aborting the run.** Root
  cause: `output_stat` returned 1 for a non-directory file with link
  count > 1; as a bare call under `errexit` that terminated the whole
  pass, and the following `[ -z "${file_name_from_stat}" ]` guard never
  caught it because the var was already set. Now blanks the output vars
  and returns 0 — matching the existing nonexistent-file skip path and
  the "cannot handle hardlinks" comment — so the caller continues.

## Testing

- `bash -n` on the modified script — no syntax errors.
- Fix 1, real `check_nosuid_whitelist` extracted and exercised under
  `set -u`: empty matchwhitelist → hardens (return 0); matching entry →
  skips (return 1); non-matching entry → hardens. All three correct;
  the empty case fails against the pre-fix function.
- Fix 2, real `output_stat` run against an actual 2-link hardlinked
  file: file is skipped, the loop continues to the next (single-link)
  file which is still hardened, and the run exits 0 instead of aborting.

## Notes for reviewers

- Decision (fix 2): only the hardlink branch was changed to skip;
  genuine error paths (stat failure, parse corruption) still `return 1`
  and fail loud under `errexit`. The alternative — `output_stat … ||
  continue` at all four call sites — is simpler but would also swallow
  those genuine errors, so it was rejected in favor of the narrower fix.
- Both defects are latent on a default install (the shipped
  `permission-hardener.d/*.conf` provide many `matchwhitelist` entries,
  and hardlinked SUID binaries are uncommon); they surface on custom
  effective configs and unusual filesystems respectively.
