### PR TITLE
docs: correct section numbering in config comments

### DIFF
--- a/etc/modprobe.d/30_security-misc_disable.conf#security-misc-shared
+++ b/etc/modprobe.d/30_security-misc_disable.conf#security-misc-shared
@@ -187,7 +187,7 @@ install nfsv2 /usr/bin/disabled-netfilesys-by-security-misc
 install nfsv3 /usr/bin/disabled-netfilesys-by-security-misc
 install nfsv4 /usr/bin/disabled-netfilesys-by-security-misc
 
-## 2. Networking:
+## 3. Networking:
 
 ## Network Protocols:
 ## Disable rare and unneeded network protocols that are a common source of unknown vulnerabilities.

--- a/usr/lib/sysctl.d/990-security-misc.conf#security-misc-shared
+++ b/usr/lib/sysctl.d/990-security-misc.conf#security-misc-shared
@@ -12,7 +12,7 @@
 ## KSPP=no: not (currently) compliant with recommendations by the KSPP
 ## If there is no explicit KSPP compliance notice, the setting is not mentioned by the KSPP.
 
-## This configuration file is divided into 5 sections:
+## This configuration file is divided into 6 sections:
 ## 1. Kernel Space
 ## 2. User Space
 ## 3. Core Dumps


### PR DESCRIPTION
## Summary

The comment-based section numbering in two hardening config files has drifted out of sync with the sections they actually contain, which misleads anyone navigating the files. This corrects both.

## Changes

- `usr/lib/sysctl.d/990-security-misc.conf`: the header states the file is divided into 5 sections, but the list immediately below enumerates 6 (through `6. CD-ROM/DVD`) — update the count to 6.
- `etc/modprobe.d/30_security-misc_disable.conf`: the Networking section header reads `## 2. Networking`, duplicating the File Systems section; the file's own table of contents and the following `## 4. Miscellaneous` header confirm it should be `## 3. Networking`.

## Testing

- Comment-only change; no automated tests apply. Each corrected number was cross-checked against the section list and table of contents within the same file.
