### PR TITLE
fix(pam-info): restore deny default when faillock.conf lacks it

### DIFF
--- a/usr/libexec/security-misc/pam-info#security-misc-shared
+++ b/usr/libexec/security-misc/pam-info#security-misc-shared
@@ -248,6 +248,10 @@ deny=3
 if test -f /etc/security/faillock.conf ; then
    deny_line=$(grep --invert-match "#" -- /etc/security/faillock.conf | grep -- "deny =") || true
    deny="$(printf '%s\n' "$deny_line" | str_replace "=" "" | str_replace "deny" "" | str_replace " " "")"
+   ## Restore the default if no uncommented 'deny =' line was found; an empty
+   ## value would slip past the numeric guard below and incorrectly report a
+   ## lockout.
+   [ -n "$deny" ] || deny=3
    ## Example:
    #deny=50
 fi


### PR DESCRIPTION
## Summary

`pam-info` (the failed-login notifier shown on login/su) can tell a user
their account is locked and to boot into recovery mode when it is not.
This restores the script's own documented `deny` default so the message
stays accurate.

## Changes

- Root cause: when `/etc/security/faillock.conf` has no uncommented
  `deny =` line (commented out, or written as `deny=N` without spaces),
  the parse overwrites the `deny=3` default with an empty string. Empty
  slips past the `[[ "$deny" == *[!0-9]* ]]` numeric guard, then evaluates
  to `0` in `$(( deny - failed_login_counter ))`, so `remaining_attempts`
  goes negative and the "Login blocked" branch fires.
- Fall back to `deny=3` when the parse yields empty, re-arming the
  fallback the code already documents at the top of the block.

## Testing

- `bash -n` on the script — no syntax errors.
- Manual reproduction of the parse across config shapes: an
  empty/commented/space-less `deny` previously bypassed the numeric guard
  and produced the false lockout; with the fix it falls back to `3` and
  shows remaining attempts. `deny = 50` and `deny = 3` are unchanged.

## Notes for reviewers

- Latent on a stock install: security-misc ships
  `etc/security/faillock.conf.security-misc` with an uncommented
  `deny = 50`, so the parse succeeds there. The bug surfaces when the
  effective `/etc/security/faillock.conf` diverges (plain Debian ships
  `deny` commented, or a hand-edited `deny=50` without spaces).
