### PR TITLE
fix(hide-hardware-info): look up group with getent

### DIFF
--- a/usr/libexec/security-misc/hide-hardware-info#security-misc-shared
+++ b/usr/libexec/security-misc/hide-hardware-info#security-misc-shared
@@ -48,7 +48,7 @@ create_whitelist() {
     exit 1
   fi
 
-  if grep -q "${1}" /etc/group; then
+  if getent group "${1}" >/dev/null; then
     ## Changing the permissions of /sys recursively
     ## causes errors as the permissions of /sys/kernel/debug
     ## and /sys/fs/cgroup cannot be changed.


### PR DESCRIPTION
## Summary

`hide-hardware-info` decides whether to hand `/sys` (or `/proc/cpuinfo`) to a
dedicated whitelist group based on whether that group exists, but tested
existence with an unanchored `grep` over `/etc/group` that false-matches. This
switches the check to an exact, NSS-aware `getent` lookup.

## Changes

- Root cause: `grep -q "${1}" /etc/group` matched the group name (`sysfs` /
  `cpuinfo`) as a substring anywhere in the file — including inside a longer
  group name or a group's comma-separated member list. On a false positive the
  branch ran `chgrp` against a group that does not exist (silently swallowed by
  `|| true`) and suppressed the "group does not exist" warning, so the whitelist
  quietly did nothing while the code path reported success.
- Replace the check with `getent group "${1}"`, which matches by exact group
  name/GID and consults NSS, so groups from non-file sources (LDAP,
  systemd-userdb, SSS) are recognized too.

## Testing

- `bash -n usr/libexec/security-misc/hide-hardware-info#security-misc-shared` —
  parses cleanly.
- False-positive repro (reviewer-runnable): `printf 'plugdev:x:46:sysfs\n' |
  grep -q sysfs` matches (exit 0) although no group named `sysfs` exists, whereas
  `getent group sysfs` returns no such group (exit 2) on the same host.
- Not run: end-to-end execution (`chgrp`/`chmod` on a live `/sys` with a real
  whitelist group) requires root and mutates system state; the change is
  isolated to the existence check.

## Notes for reviewers

- No behavior change when a group genuinely named `sysfs`/`cpuinfo` exists —
  `getent` and the old `grep` both match; only the false-positive paths differ.
