### PR TITLE
udev: mark optical drives UDISKS_IGNORE (quiet + harden)

### DIFF
--- a/debian/security-misc-shared.install
+++ b/debian/security-misc-shared.install
@@ -106,6 +106,7 @@ usr/lib/systemd/system/usbguard.service.d/30_security-misc.conf#security-misc-sh
 usr/lib/systemd/system/user@.service.d/sysfs.conf#security-misc-shared => /usr/lib/systemd/system/user@.service.d/sysfs.conf
 usr/lib/systemd/user/fm-shim.service#security-misc-shared => /usr/lib/systemd/user/fm-shim.service
 usr/lib/systemd/user/usbguard-notifier.service.d/30_security-misc.conf#security-misc-shared => /usr/lib/systemd/user/usbguard-notifier.service.d/30_security-misc.conf
+usr/lib/udev/rules.d/70-udisks-ignore-optical.rules#security-misc-shared => /usr/lib/udev/rules.d/70-udisks-ignore-optical.rules
 usr/lib/udev/rules.d/95-emerg-shutdown.rules#security-misc-shared => /usr/lib/udev/rules.d/95-emerg-shutdown.rules
 usr/libexec/security-misc/askpass#security-misc-shared => /usr/libexec/security-misc/askpass
 usr/libexec/security-misc/block-unsafe-logins#security-misc-shared => /usr/libexec/security-misc/block-unsafe-logins

--- a/usr/lib/udev/rules.d/70-udisks-ignore-optical.rules#security-misc-shared
+++ b/usr/lib/udev/rules.d/70-udisks-ignore-optical.rules#security-misc-shared
@@ -1,0 +1,16 @@
+# Copyright (C) 2012 - 2025 ENCRYPTED SUPPORT LLC <adrelanos@whonix.org>
+# See the file COPYING for copying conditions.
+
+# Do not let udisks auto-probe optical drives.
+#
+# udisks probing removable optical media (sr*) is noisy and unnecessary: on a drive with no or
+# inert media -- e.g. a VM's emulated CD-ROM -- it errors repeatedly ("udisksd: Error probing
+# device: Error sending ATA command IDENTIFY PACKET DEVICE to /dev/sr0"). More importantly,
+# auto-probing inserted removable media is avoidable attack surface: media should not be
+# auto-processed without user action. Mark optical drives UDISKS_IGNORE so udisks leaves them
+# alone.
+#
+# This does NOT affect booting the live ISO from an optical drive: the live medium is mounted by
+# the initramfs (rd.live.*) in early boot, not by userspace udisks, so ignoring optical drives in
+# udisks has no bearing on rd.live. It also does not block a user from mounting media manually.
+KERNEL=="sr[0-9]*", ENV{UDISKS_IGNORE}="1"


### PR DESCRIPTION
udisks auto-probing removable optical media (`sr*`) is noisy -- on a drive with no or inert media (e.g. a VM CD-ROM) it errors repeatedly (`udisksd: Error probing device: Error sending ATA command IDENTIFY PACKET DEVICE to /dev/sr0`) -- and is avoidable attack surface: inserted media should not be auto-processed without user action. This adds a udev rule marking optical drives `UDISKS_IGNORE`.

Does NOT affect booting the live ISO from optical media: `rd.live` mounts the medium in the initramfs, not via userspace udisks.

Found via `systemcheck --leak-tests` headless in qemu. Not yet runtime-validated on a rebuilt image.

AI-Assisted.